### PR TITLE
Fixes #8 - updating to adhere more strictly to the interface

### DIFF
--- a/src/groovy/asset/pipeline/groovytemplate/JavascriptUrlAwareProcessor.groovy
+++ b/src/groovy/asset/pipeline/groovytemplate/JavascriptUrlAwareProcessor.groovy
@@ -2,6 +2,7 @@ package asset.pipeline.groovytemplate
 
 import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
 import groovy.util.logging.Log4j
 
@@ -13,7 +14,7 @@ class JavascriptUrlAwareProcessor extends AbstractProcessor {
     }
 
     @Override
-    def process(inputText, assetFile) {
+    String process(String inputText, AssetFile assetFile) {
 
         if (!this.precompiler) return inputText
 


### PR DESCRIPTION
Somewhere between asset-pipeline 1.8.9 and 2.0.19 the compiler got  picky about this method implementation.  Updating it to explicitly set the parameter and return types.
